### PR TITLE
Update Question.cs

### DIFF
--- a/Bdev.Net.Dns/Question.cs
+++ b/Bdev.Net.Dns/Question.cs
@@ -39,7 +39,7 @@ namespace Bdev.Net.Dns
 
             // do a sanity check on the domain name to make sure its legal
             if (domain.Length == 0 || domain.Length > 255 ||
-                !Regex.IsMatch(domain, @"^[a-z|A-Z|0-9|-|_]{1,63}(\.[a-z|A-Z|0-9|-|_]{1,63})+$"))
+                !Regex.IsMatch(domain, @"^[a-zA-Z0-9-_]{1,63}(\.[a-zA-Z0-9-_]{1,63})+$"))
             {
                 // domain names can't be bigger tan 255 chars, and individal labels can't be bigger than 63 chars
                 throw new ArgumentException("The supplied domain name was not in the correct form", "domain");


### PR DESCRIPTION
Changed the regex to not fail on names that contain hyphens.  It may even be appropriate to drop the domain name regex entirely because I would expect the server to answer the question of whether the domain name is valid.  Note that the domain name will still fail validation on names with just one part (e.g., server1, server2, etc.)
