### PR TITLE
Excape hyphens

### DIFF
--- a/Bdev.Net.Dns/Question.cs
+++ b/Bdev.Net.Dns/Question.cs
@@ -39,7 +39,7 @@ namespace Bdev.Net.Dns
 
             // do a sanity check on the domain name to make sure its legal
             if (domain.Length == 0 || domain.Length > 255 ||
-                !Regex.IsMatch(domain, @"^[a-z|A-Z|0-9|-|_]{1,63}(\.[a-z|A-Z|0-9|-|_]{1,63})+$"))
+                !Regex.IsMatch(domain, @"^[a-z|A-Z|0-9|\-|_]{1,63}(\.[a-z|A-Z|0-9|\-|_]{1,63})+$"))
             {
                 // domain names can't be bigger tan 255 chars, and individal labels can't be bigger than 63 chars
                 throw new ArgumentException("The supplied domain name was not in the correct form", "domain");


### PR DESCRIPTION
While testing this library, I found this domain regex doesn't match apx-international.com due to unescaped hyphen