### PR TITLE
Fix TXT records with multiple strings

### DIFF
--- a/Bdev.Net.Dns/Pointer.cs
+++ b/Bdev.Net.Dns/Pointer.cs
@@ -51,6 +51,11 @@ namespace Bdev.Net.Dns
         }
 
         /// <summary>
+        ///     Gets the cursor position
+        /// </summary>
+        public int Position { get { return _position; } }
+
+        /// <summary>
         ///     Overloads the + operator to allow advancing the pointer by so many bytes
         /// </summary>
         /// <param name="pointer">the initial pointer</param>

--- a/Bdev.Net.Dns/Records/TXTRecord.cs
+++ b/Bdev.Net.Dns/Records/TXTRecord.cs
@@ -7,15 +7,26 @@ namespace Bdev.Net.Dns.Records
         public string Value { get; set; }
 
         public int Length { get; set; }
-        internal TXTRecord(Pointer pointer)
+        internal TXTRecord(Pointer pointer, int recordLength)
         {
-            Length = pointer.ReadByte();
-            var sb = new StringBuilder(Length);
-            for (int i = 0; i < Length; i++)
+            var position = pointer.Position;
+
+            var sb = new StringBuilder(recordLength);
+
+            // there can be multiple strings in one TXT record
+            // loop until full recordLength is read
+            while (pointer.Position - position < recordLength)
             {
-                sb.Append(pointer.ReadChar());
+                // read the string length
+                var length = pointer.ReadByte();
+                for (int i = 0; i < length; i++)
+                {
+                    sb.Append(pointer.ReadChar());
+                }
             }
+
             Value = sb.ToString();
+            Length = sb.Length;
         }
 
         public override string ToString()

--- a/Bdev.Net.Dns/ResourceRecord.cs
+++ b/Bdev.Net.Dns/ResourceRecord.cs
@@ -53,7 +53,7 @@ namespace Bdev.Net.Dns
                     Record = new SoaRecord(pointer);
                     break;
                 case DnsType.TXT:
-                    Record = new TXTRecord(pointer);
+                    Record = new TXTRecord(pointer, recordLength);
                     break;
                 default:
                 {


### PR DESCRIPTION
This is a fix for #4 TXT records can contain multiple length prefixed strings.