### PR TITLE
Fix CNAME lookup

### DIFF
--- a/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
+++ b/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
@@ -69,6 +69,14 @@ namespace Bdev.Net.Dns.NUnit
         }
 
         [Test]
+        public void CorrectCNameForGmail()
+        {
+            var result = DnsServers.Resolve<CNameRecord>("mail.google.com").First();
+
+            Assert.AreEqual(result.Value, "googlemail.l.google.com");
+        }
+
+        [Test]
         public void CorrectANameForCodeProject()
         {
             var response = DnsServers.Resolve("codeproject.com").ToList();

--- a/Bdev.Net.Dns/Records/TXTRecord.cs
+++ b/Bdev.Net.Dns/Records/TXTRecord.cs
@@ -39,16 +39,9 @@ namespace Bdev.Net.Dns.Records
     {
         public string Value { get; set; }
 
-        public int Length { get; set; }
         internal CNameRecord(Pointer pointer)
         {
-            Length = pointer.ReadByte();
-            var sb = new StringBuilder(Length);
-            for (int i = 0; i < Length; i++)
-            {
-                sb.Append(pointer.ReadChar());
-            }
-            Value = sb.ToString();
+            Value = pointer.ReadDomain();
         }
 
         public override string ToString()


### PR DESCRIPTION
Before, doing a CNAME lookup on mail.google.com would return "googlemail"

![image](https://user-images.githubusercontent.com/15322107/163273324-3d52c141-b0ef-4197-9ffc-735ea7430dbd.png)

 whereas it should be googlemail.l.google.com

```
PS C:\Users\Indra> nslookup -q=cname mail.google.com

Non-authoritative answer:
mail.google.com canonical name = googlemail.l.google.com
```

I encountered this for every CNAME I tried so not sure if this ever worked, couple other examples are discordstatus.com, status.slack.com and opensource.zalando.com)

It seems you were only reading the length of the first part of the RDATA, this is fixed after using `Pointer.ReadDomain` here. tested with various domains and also added a test for mail.google.com to the unit tests.

![image](https://user-images.githubusercontent.com/15322107/163272945-321e148b-87c1-4d3e-89d0-250a1fc8518d.png)