### PR TITLE
Add support for AAAA records (RFC3596)

### DIFF
--- a/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
+++ b/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
@@ -144,7 +144,7 @@ namespace Bdev.Net.Dns.NUnit
         [Test]
         public void CorrectAAAAForCloudflare()
         {
-            var result = DnsServers.Resolve<AAAARecord>("one.one.one.one").ToList();
+            var result = DnsServers.Resolve<AaaaRecord>("one.one.one.one").ToList();
 
             Assert.AreEqual(IPAddress.Parse("2606:4700:4700::1111"), result[0].IPAddress);
             Assert.AreEqual(IPAddress.Parse("2606:4700:4700::1001"), result[1].IPAddress);

--- a/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
+++ b/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
@@ -142,6 +142,15 @@ namespace Bdev.Net.Dns.NUnit
         }
 
         [Test]
+        public void CorrectAAAAForCloudflare()
+        {
+            var result = DnsServers.Resolve<AAAARecord>("one.one.one.one").ToList();
+
+            Assert.AreEqual(IPAddress.Parse("2606:4700:4700::1111"), result[0].IPAddress);
+            Assert.AreEqual(IPAddress.Parse("2606:4700:4700::1001"), result[1].IPAddress);
+        }
+
+        [Test]
         [ExpectedException(typeof(NoResponseException))]
         public void NoResponseForBadDnsAddress()
         {

--- a/Bdev.Net.Dns/Bdev.Net.Dns.csproj
+++ b/Bdev.Net.Dns/Bdev.Net.Dns.csproj
@@ -5,9 +5,9 @@
     <TargetFrameworks>net48;net45;net462;net472;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Title>Bdev.Net.Dns</Title>
     <Description>.NET DNS query library</Description>
-    <Authors>Rob Philpott, Indra, and Dariusz Danielewski</Authors>
+    <Authors>Rob Philpott, Indra van den Berg, and Dariusz Danielewski</Authors>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) $(CurrentYear) Rob Philpott, Indra and Dariusz Danielewski</Copyright>
+    <Copyright>Copyright (c) $(CurrentYear) Rob Philpott, Indra van den Berg and Dariusz Danielewski</Copyright>
     <PackageTags>dns</PackageTags>
     <PackageIconUrl></PackageIconUrl>
     <PackageProjectUrl>https://www.codeproject.com/Articles/12072/C-NET-DNS-query-component</PackageProjectUrl>

--- a/Bdev.Net.Dns/Enums.cs
+++ b/Bdev.Net.Dns/Enums.cs
@@ -31,7 +31,8 @@ namespace Bdev.Net.Dns
         HINFO = 13, //host information
         MINFO = 14, //mailbox or mail list information
         MX = 15, //mail exchange
-        TXT = 16 //text strings
+        TXT = 16, //text strings
+        AAAA = 28 //ipv6 host address
     }
 
     /// <summary>

--- a/Bdev.Net.Dns/Helpers/DnsServers.cs
+++ b/Bdev.Net.Dns/Helpers/DnsServers.cs
@@ -35,7 +35,7 @@ namespace Bdev.Net.Dns.Helpers
             {typeof(NSRecord), DnsType.NS},
             {typeof(SoaRecord), DnsType.SOA},
             {typeof(TXTRecord), DnsType.TXT},
-            {typeof(AAAARecord), DnsType.AAAA}
+            {typeof(AaaaRecord), DnsType.AAAA},
         };
 
         public static IEnumerable<ANameRecord> Resolve(string name)

--- a/Bdev.Net.Dns/Helpers/DnsServers.cs
+++ b/Bdev.Net.Dns/Helpers/DnsServers.cs
@@ -34,7 +34,8 @@ namespace Bdev.Net.Dns.Helpers
             {typeof(MXRecord), DnsType.MX},
             {typeof(NSRecord), DnsType.NS},
             {typeof(SoaRecord), DnsType.SOA},
-            {typeof(TXTRecord), DnsType.TXT}
+            {typeof(TXTRecord), DnsType.TXT},
+            {typeof(AAAARecord), DnsType.AAAA}
         };
 
         public static IEnumerable<ANameRecord> Resolve(string name)

--- a/Bdev.Net.Dns/Pointer.cs
+++ b/Bdev.Net.Dns/Pointer.cs
@@ -115,7 +115,7 @@ namespace Bdev.Net.Dns
         /// <summary>
         ///     Reads a specified number of bytes at the current pointer, advancing pointer
         /// </summary>
-        /// <param name="length">The number of bytes to read</param>
+        /// <param name="length">the number of bytes to read</param>
         /// <returns>the bytes at the pointer</returns>
         public byte[] ReadBytes(int length)
         {

--- a/Bdev.Net.Dns/Pointer.cs
+++ b/Bdev.Net.Dns/Pointer.cs
@@ -8,6 +8,7 @@
 
 #endregion
 
+using System;
 using System.Linq;
 using System.Text;
 
@@ -109,6 +110,21 @@ namespace Bdev.Net.Dns
         public char ReadChar()
         {
             return (char) ReadByte();
+        }
+
+        /// <summary>
+        ///     Reads a specified number of bytes at the current pointer, advancing pointer
+        /// </summary>
+        /// <param name="length">The number of bytes to read</param>
+        /// <returns>the bytes at the pointer</returns>
+        public byte[] ReadBytes(int length)
+        {
+            var data = new byte[length];
+
+            Buffer.BlockCopy(_message, _position, data, 0, length);
+            _position += length;
+
+            return data;
         }
 
         /// <summary>

--- a/Bdev.Net.Dns/Records/AAAARecord.cs
+++ b/Bdev.Net.Dns/Records/AAAARecord.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Bdev.Net.Dns.Records
+{
+    /// <summary>
+    ///     AAAA Resource Record (RR) (RFC3596 2.2)
+    /// </summary>
+    public class AAAARecord : RecordBase, IEquatable<AAAARecord>
+    {
+        /// <summary>
+        ///     Constructs an AAAA record by reading bytes from a return message
+        /// </summary>
+        /// <param name="pointer">A logical pointer to the bytes holding the record</param>
+        internal AAAARecord(Pointer pointer)
+        {
+            IPAddress = new IPAddress(pointer.ReadBytes(16));
+        }
+
+        /// <summary>
+        /// Gets the IPv6 address of the record
+        /// </summary>
+        public IPAddress IPAddress { get; }
+
+        public bool Equals(AAAARecord other)
+        {
+            return other != null &&
+                   EqualityComparer<IPAddress>.Default.Equals(IPAddress, other.IPAddress);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AAAARecord);
+        }
+
+        public override int GetHashCode()
+        {
+            return -2138420020 + EqualityComparer<IPAddress>.Default.GetHashCode(IPAddress);
+        }
+
+        public override string ToString()
+        {
+            return IPAddress.ToString();
+        }
+
+        public static bool operator ==(AAAARecord record1, AAAARecord record2)
+        {
+            return EqualityComparer<AAAARecord>.Default.Equals(record1, record2);
+        }
+
+        public static bool operator !=(AAAARecord record1, AAAARecord record2)
+        {
+            return !(record1 == record2);
+        }
+    }
+}

--- a/Bdev.Net.Dns/Records/AAAARecord.cs
+++ b/Bdev.Net.Dns/Records/AAAARecord.cs
@@ -5,25 +5,25 @@ using System.Net;
 namespace Bdev.Net.Dns.Records
 {
     /// <summary>
-    ///     AAAA Resource Record (RR) (RFC3596 2.2)
+    ///     An AAAA Resource Record (RR) (RFC3596 2.2)
     /// </summary>
-    public class AAAARecord : RecordBase, IEquatable<AAAARecord>
+    public class AaaaRecord : RecordBase, IEquatable<AaaaRecord>
     {
         /// <summary>
         ///     Constructs an AAAA record by reading bytes from a return message
         /// </summary>
         /// <param name="pointer">A logical pointer to the bytes holding the record</param>
-        internal AAAARecord(Pointer pointer)
+        internal AaaaRecord(Pointer pointer)
         {
             IPAddress = new IPAddress(pointer.ReadBytes(16));
         }
 
         /// <summary>
-        /// Gets the IPv6 address of the record
+        ///     Gets the IPv6 address of the record
         /// </summary>
         public IPAddress IPAddress { get; }
 
-        public bool Equals(AAAARecord other)
+        public bool Equals(AaaaRecord other)
         {
             return other != null &&
                    EqualityComparer<IPAddress>.Default.Equals(IPAddress, other.IPAddress);
@@ -31,7 +31,7 @@ namespace Bdev.Net.Dns.Records
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as AAAARecord);
+            return Equals(obj as AaaaRecord);
         }
 
         public override int GetHashCode()
@@ -44,12 +44,12 @@ namespace Bdev.Net.Dns.Records
             return IPAddress.ToString();
         }
 
-        public static bool operator ==(AAAARecord record1, AAAARecord record2)
+        public static bool operator ==(AaaaRecord record1, AaaaRecord record2)
         {
-            return EqualityComparer<AAAARecord>.Default.Equals(record1, record2);
+            return EqualityComparer<AaaaRecord>.Default.Equals(record1, record2);
         }
 
-        public static bool operator !=(AAAARecord record1, AAAARecord record2)
+        public static bool operator !=(AaaaRecord record1, AaaaRecord record2)
         {
             return !(record1 == record2);
         }

--- a/Bdev.Net.Dns/ResourceRecord.cs
+++ b/Bdev.Net.Dns/ResourceRecord.cs
@@ -55,6 +55,9 @@ namespace Bdev.Net.Dns
                 case DnsType.TXT:
                     Record = new TXTRecord(pointer, recordLength);
                     break;
+                case DnsType.AAAA:
+                    Record = new AAAARecord(pointer);
+                    break;
                 default:
                 {
                     // move the pointer over this unrecognized record

--- a/Bdev.Net.Dns/ResourceRecord.cs
+++ b/Bdev.Net.Dns/ResourceRecord.cs
@@ -56,7 +56,7 @@ namespace Bdev.Net.Dns
                     Record = new TXTRecord(pointer, recordLength);
                     break;
                 case DnsType.AAAA:
-                    Record = new AAAARecord(pointer);
+                    Record = new AaaaRecord(pointer);
                     break;
                 default:
                 {

--- a/DnsExample/DnsTestApp.cs
+++ b/DnsExample/DnsTestApp.cs
@@ -29,7 +29,8 @@ namespace DnsExample
                 Console.WriteLine("Querying DNS records for domain: " + domain);
 
                 // query AName, MX, NS, SOA
-                Query(dnsServer, domain, DnsType.ANAME);
+                Query(dnsServer, domain, DnsType.A);
+                Query(dnsServer, domain, DnsType.AAAA);
                 Query(dnsServer, domain, DnsType.MX);
                 Query(dnsServer, domain, DnsType.NS);
                 Query(dnsServer, domain, DnsType.SOA);


### PR DESCRIPTION
Adds support for AAAA records for IPv6 as described in RFC3596.

~~The record class is called `AAAARecord`, this matches the other class names but breaks the [Microsoft Capitalization Conventions](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions). So please let me know which your prefer.~~

For some reason I wasn't able to run the tests with Visual Studio, but I've added a test and done some of my own testing too.

![image](https://github.com/DarekDan/Bdev.Net.Dns/assets/15322107/3e7c2c55-5246-4ff0-95fd-fa3263404223)