### PR TITLE
Update Resolver.cs

### DIFF
--- a/Bdev.Net.Dns/Resolver.cs
+++ b/Bdev.Net.Dns/Resolver.cs
@@ -141,8 +141,8 @@ namespace Bdev.Net.Dns
                 // we'll be send and receiving a UDP packet
                 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
-                // we will wait at most 1 second for a dns reply
-                socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, 1000);
+                // we will wait at most 5 seconds for a dns reply
+                socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, 5000);
 
                 // send it off to the server
                 socket.SendTo(requestMessage, requestMessage.Length, SocketFlags.None, server);


### PR DESCRIPTION
Wait 5 seconds for a dns request to complete.

Matches the defaults used in other pieces of software.

Windows nslookup 5 seconds:
https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc788023(v=ws.11) "Specifies the number of seconds to wait for a reply. The default number of seconds to wait is 5."

dig: defaults to 5 seconds

Linux: 5 seconds
https://man7.org/linux/man-pages/man5/resolver.5.html