### PR TITLE
Add more record types

### DIFF
--- a/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
+++ b/Bdev.Net.Dns.NUnit/CorrectBehaviour.cs
@@ -175,9 +175,38 @@ namespace Bdev.Net.Dns.NUnit
             Logger.Info($"{result[1].IPAddress}");
 
             Assert.True(result.Select(s=>s.IPAddress).SequenceEqual(new []{ IPAddress.Parse("2606:4700:4700::1111"), IPAddress.Parse("2606:4700:4700::1001") }));
-
-           
         }
 
+        [Test]
+        public void CorrectSRVForDebian()
+        {
+            var result = DnsServers.Resolve<SRVRecord>("_http._tcp.ftp.debian.org").First();
+
+            Assert.AreEqual(10, result.Priority);
+            Assert.AreEqual(1, result.Weight);
+            Assert.AreEqual(80, result.Port);
+            Assert.AreEqual("debian.map.fastlydns.net", result.Target);
+        }
+
+        [Test]
+        public void CorrectDSForIana()
+        {
+            var result = DnsServers.Resolve<DSRecord>("iana.org").First();
+
+            Assert.AreEqual(39229, result.KeyTag);
+            Assert.AreEqual(DnsSecAlgorithm.ECDSAP256SHA256, result.Algorithm);
+            Assert.AreEqual(DnsSecDigestType.SHA256, result.DigestType);
+            Assert.IsNotEmpty(result.Digest);
+        }
+
+        [Test]
+        public void LookupShortRecordType()
+        {
+            // looks up a record type that exceeds a single octet
+            var result = Resolver.Lookup("google.com", DnsType.CAA);
+
+            Assert.True(result.Questions.All(q => q.Type == DnsType.CAA));
+            Assert.True(result.Answers.All(a => a.Type == DnsType.CAA));
+        }
     }
 }

--- a/Bdev.Net.Dns/Enums.cs
+++ b/Bdev.Net.Dns/Enums.cs
@@ -32,7 +32,14 @@ namespace Bdev.Net.Dns
         MINFO = 14, //mailbox or mail list information
         MX = 15, //mail exchange
         TXT = 16, //text strings
-        AAAA = 28 // ipv6 host address
+        AAAA = 28, // ipv6 host address
+        SRV = 33, //server selection
+        DS = 43, //delegation signer
+        RRSIG = 46, //resource record signature
+        NSEC = 47, //next secure
+        DNSKEY = 48, //public key
+        NSEC3 = 50, //hashed next secure
+        CAA = 257 //certification authority authorization
     }
 
     /// <summary>
@@ -84,5 +91,46 @@ namespace Bdev.Net.Dns
         Reserved13 = 13,
         Reserved14 = 14,
         Reserved15 = 15
+    }
+
+    /// <summary>
+    /// The DNSSEC Algorithm Numbers (RFC4034)
+    /// https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
+    /// </summary>
+    public enum DnsSecAlgorithm
+    {
+        RSAMD5 = 1, //RSA/MD5
+        DH = 2, //Diffie-Hellman
+        DSA = 3, //DSA/SHA1
+        ECC = 4, //Elliptic Curve
+        RSASHA1 = 5, //RSA/SHA-1
+        DSANSEC3SHA1 = 6, //DSA-NSEC3-SHA1
+        RSASHA1NSEC3SHA1 = 7, //RSASHA1-NSEC3-SHA1
+        RSASHA256 = 8, //RSA/SHA-256
+        RSASHA512 = 10, //RSA/SHA-512
+        ECCGOST = 12, //GOST R 34.10-2001
+        ECDSAP256SHA256 = 13, //ECDSA Curve P-256 with SHA-256
+        ECDSAP384SHA384 = 14, //ECDSA Curve P-384 with SHA-384
+        ED25519 = 15, //Ed25519
+        ED448 = 16, //Ed448
+        SM2SM3 = 17, //SM2 signing algorithm with SM3 hashing algorithm
+        ECCGOST12 = 23, //GOST R 34.10-2012
+        INDIRECT = 252,
+        PRIVATEDNS = 253,
+        PRIVATEOID = 254
+    }
+
+    /// <summary>
+    /// The DNSSEC Type Digest Algorithms (RFC4034)
+    /// https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
+    /// </summary>
+    public enum DnsSecDigestType
+    {
+        SHA1 = 1, //SHA-1
+        SHA256 = 2, //SHA-256
+        GOST = 3, //GOST R 34.11-94
+        SHA384 = 4, //SHA-384
+        GOST12 = 5, //GOST R 34.11-2012
+        SM3 = 6 //SM3
     }
 }

--- a/Bdev.Net.Dns/Exceptions/InvalidResponseException.cs
+++ b/Bdev.Net.Dns/Exceptions/InvalidResponseException.cs
@@ -34,7 +34,7 @@ namespace Bdev.Net.Dns.Exceptions
             // no implementation
         }
 
-#if !NET7_0 && !NET8_0  && !NET9_0
+#if !NET7_0_OR_GREATER
         protected InvalidResponseException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             // no implementation

--- a/Bdev.Net.Dns/Exceptions/NoResponseException.cs
+++ b/Bdev.Net.Dns/Exceptions/NoResponseException.cs
@@ -34,7 +34,7 @@ namespace Bdev.Net.Dns.Exceptions
             // no implementation
         }
 
-#if !NET7_0 && !NET8_0  && !NET9_0
+#if !NET7_0_OR_GREATER
         protected NoResponseException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             // no implementation

--- a/Bdev.Net.Dns/Helpers/DnsServers.cs
+++ b/Bdev.Net.Dns/Helpers/DnsServers.cs
@@ -36,6 +36,8 @@ namespace Bdev.Net.Dns.Helpers
             {typeof(SoaRecord), DnsType.SOA},
             {typeof(TXTRecord), DnsType.TXT},
             {typeof(AAAARecord), DnsType.AAAA},
+            {typeof(SRVRecord), DnsType.SRV},
+            {typeof(DSRecord), DnsType.DS},
         };
 
         public static IEnumerable<ANameRecord> Resolve(string name)

--- a/Bdev.Net.Dns/Pointer.cs
+++ b/Bdev.Net.Dns/Pointer.cs
@@ -98,6 +98,15 @@ namespace Bdev.Net.Dns
         }
 
         /// <summary>
+        ///     Reads two bytes to form an unsigned short at the current pointer, advancing pointer
+        /// </summary>
+        /// <returns>the byte at the pointer</returns>
+        public ushort ReadUShort()
+        {
+            return (ushort)((ReadByte() << 8) | ReadByte());
+        }
+
+        /// <summary>
         ///     Reads four bytes to form a int at the current pointer, advancing pointer
         /// </summary>
         /// <returns>the byte at the pointer</returns>

--- a/Bdev.Net.Dns/Records/CNameRecord.cs
+++ b/Bdev.Net.Dns/Records/CNameRecord.cs
@@ -4,7 +4,7 @@ namespace Bdev.Net.Dns.Records
 {
     public class CNameRecord : RecordBase, IComparable, IEquatable<CNameRecord>
     {
-        public string Value { get; set; }
+        public string Value { get; }
 
         internal CNameRecord(Pointer pointer)
         {

--- a/Bdev.Net.Dns/Records/DSRecord.cs
+++ b/Bdev.Net.Dns/Records/DSRecord.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bdev.Net.Dns.Records
+{
+    /// <summary>
+    ///     An DS Resource Record (RR) (RFC4034 5.1)
+    /// </summary>
+    public class DSRecord : RecordBase, IEquatable<DSRecord>
+    {
+        /// <summary>
+        ///     Constructs an DS record by reading bytes from a return message
+        /// </summary>
+        /// <param name="pointer">A logical pointer to the bytes holding the record</param>
+        /// <param name="recordLength">The length of the record in bytes</param>
+        internal DSRecord(Pointer pointer, int recordLength)
+        {
+            KeyTag = pointer.ReadUShort();
+            Algorithm = (DnsSecAlgorithm)pointer.ReadByte();
+            DigestType = (DnsSecDigestType)pointer.ReadByte();
+            Digest = pointer.ReadBytes(recordLength - 4);
+        }
+
+        /// <summary>
+        ///     Gets the key tag of the record
+        /// </summary>
+        public int KeyTag { get; }
+
+        /// <summary>
+        ///     Gets the algorithm of the record
+        /// </summary>
+        public DnsSecAlgorithm Algorithm { get; }
+
+        /// <summary>
+        ///     Gets the digest type of the record
+        /// </summary>
+        public DnsSecDigestType DigestType { get; }
+
+        /// <summary>
+        ///     Gets the digest of the record
+        /// </summary>
+        public IReadOnlyList<byte> Digest { get; }
+
+        public override string ToString()
+        {
+            var digest = string.Concat(Digest.Select(b => b.ToString("X2")));
+
+            return $"Key Tag = {KeyTag}, Algorithm = {Algorithm}, Digest Type = {DigestType}, Digest = {digest}";
+        }
+
+        #region IEquatable Members
+
+        public bool Equals(DSRecord other)
+        {
+            return other != null &&
+                KeyTag == other.KeyTag &&
+                Algorithm == other.Algorithm &&
+                DigestType == other.DigestType &&
+                Digest.SequenceEqual(other.Digest);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as DSRecord);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1152426255;
+            hashCode = hashCode * -1521134295 + KeyTag.GetHashCode();
+            hashCode = hashCode * -1521134295 + Algorithm.GetHashCode();
+            hashCode = hashCode * -1521134295 + DigestType.GetHashCode();
+            hashCode = hashCode * -1521134295 + ((IStructuralEquatable)Digest).GetHashCode(EqualityComparer<byte>.Default);
+            return hashCode;
+        }
+
+        public static bool operator ==(DSRecord record1, DSRecord record2)
+        {
+            return EqualityComparer<DSRecord>.Default.Equals(record1, record2);
+        }
+
+        public static bool operator !=(DSRecord record1, DSRecord record2)
+        {
+            return !(record1 == record2);
+        }
+
+        #endregion
+    }
+}

--- a/Bdev.Net.Dns/Records/SRVRecord.cs
+++ b/Bdev.Net.Dns/Records/SRVRecord.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace Bdev.Net.Dns.Records
+{
+    /// <summary>
+    ///     An SRV Resource Record (RR) (RFC2782)
+    /// </summary>
+    public class SRVRecord : RecordBase, IComparable, IEquatable<SRVRecord>
+    {
+        /// <summary>
+        ///     Constructs an SRV record by reading bytes from a return message
+        /// </summary>
+        /// <param name="pointer">A logical pointer to the bytes holding the record</param>
+        internal SRVRecord(Pointer pointer)
+        {
+            Priority = pointer.ReadShort();
+            Weight = pointer.ReadShort();
+            Port = pointer.ReadShort();
+            Target = pointer.ReadDomain();
+        }
+
+        /// <summary>
+        ///     Gets the priority of the record
+        /// </summary>
+        public int Priority { get; }
+
+        /// <summary>
+        ///     Gets the weight of the record
+        /// </summary>
+        public int Weight { get; }
+
+        /// <summary>
+        ///     Gets the service port of the record
+        /// </summary>
+        public int Port { get; }
+
+        /// <summary>
+        ///     Gets the target domain name of the record
+        /// </summary>
+        public string Target { get; }
+
+        public override string ToString()
+        {
+            return $"Priority = {Priority}, Weight = {Weight}, Port = {Port}, Target = {Target}";
+        }
+
+        #region IEquatable Members
+
+        public bool Equals(SRVRecord other)
+        {
+            return other != null &&
+                Priority == other.Priority &&
+                Weight == other.Weight &&
+                Port == other.Port &&
+                Target == other.Target;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SRVRecord);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1394496566;
+            hashCode = hashCode * -1521134295 + Priority.GetHashCode();
+            hashCode = hashCode * -1521134295 + Weight.GetHashCode();
+            hashCode = hashCode * -1521134295 + Port.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Target);
+            return hashCode;
+        }
+
+        public static bool operator ==(SRVRecord record1, SRVRecord record2)
+        {
+            return EqualityComparer<SRVRecord>.Default.Equals(record1, record2);
+        }
+
+        public static bool operator !=(SRVRecord record1, SRVRecord record2)
+        {
+            return !(record1 == record2);
+        }
+
+        #endregion
+
+        #region IComparable Members
+
+        public int CompareTo(object obj)
+        {
+            var other = obj as SRVRecord;
+
+            if (Priority == other.Priority) return Weight.CompareTo(other.Weight);
+            return Priority.CompareTo(other.Priority);
+        }
+
+        public static bool operator <(SRVRecord record1, SRVRecord record2)
+        {
+            if (record1.Priority == record2.Priority) return record1.Weight < record2.Weight;
+            return record1.Priority < record2.Priority;
+        }
+
+        public static bool operator >(SRVRecord record1, SRVRecord record2)
+        {
+            if (record1.Priority == record2.Priority) return record1.Weight > record2.Weight;
+            return record1.Priority > record2.Priority;
+        }
+
+        #endregion
+    }
+}

--- a/Bdev.Net.Dns/Request.cs
+++ b/Bdev.Net.Dns/Request.cs
@@ -105,7 +105,7 @@ namespace Bdev.Net.Dns
                     AddDomain(data, question.Domain);
                     unchecked
                     {
-                        data.WriteByte(0);
+                        data.WriteByte((byte) ((short) question.Type >> 8));
                         data.WriteByte((byte) question.Type);
                         data.WriteByte(0);
                         data.WriteByte((byte) question.Class);

--- a/Bdev.Net.Dns/ResourceRecord.cs
+++ b/Bdev.Net.Dns/ResourceRecord.cs
@@ -58,6 +58,12 @@ namespace Bdev.Net.Dns
                 case DnsType.AAAA:
                     Record = new AAAARecord(pointer);
                     break;
+                case DnsType.SRV:
+                    Record = new SRVRecord(pointer);
+                    break;
+                case DnsType.DS:
+                    Record = new DSRecord(pointer, recordLength);
+                    break;
                 default:
                 {
                     // move the pointer over this unrecognized record


### PR DESCRIPTION
Adds implementation for two new record types (SRV & DS) and extends the list with more popular record types.

Also fixes a bug where the record type was sent as single octet (which breaks types exceeding 255), and added an appropriate test for it.